### PR TITLE
Optimise transducers, make kext properly load, fix input reads

### DIFF
--- a/VoodooI2CSynaptics/Info.plist
+++ b/VoodooI2CSynaptics/Info.plist
@@ -20,24 +20,25 @@
 	<string>1</string>
 	<key>IOKitPersonalities</key>
 	<dict>
-		<key>VoodooI2CSynapticsDevice</key>
+		<key>VoodooI2CHIDDevice</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>IOClass</key>
 			<string>VoodooI2CSynapticsDevice</string>
-			<key>IONameMatch</key>
-			<array>
-				<string>DLL06E4</string>
-                <string>SYNA2B33</string>
-                <string>SYNA2B42</string>
-            </array>
-            <key>IOMatchCategory</key>
-            <string>IODefaultMatchCategory</string>
+			<key>IOPropertyMatch</key>
+			<dict>
+				<key>compatible</key>
+				<string>PNP0C50</string>
+			</dict>
 			<key>IOProbeScore</key>
 			<integer>200</integer>
 			<key>IOProviderClass</key>
 			<string>VoodooI2CDeviceNub</string>
+			<key>RM,deliverNotifications</key>
+			<true/>
+			<key>QuietTimeAfterTyping</key>
+			<integer>500</integer>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
+++ b/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
@@ -35,17 +35,17 @@ enum rmi_mode_type {
 };
 
 struct rmi_function {
-    unsigned page;			/* page of the function */
-    uint16_t query_base_addr;		/* base address for queries */
-    uint16_t command_base_addr;		/* base address for commands */
-    uint16_t control_base_addr;		/* base address for controls */
-    uint16_t data_base_addr;		/* base address for datas */
-    unsigned int interrupt_base;	/* cross-function interrupt number
+    unsigned page;            /* page of the function */
+    uint16_t query_base_addr;        /* base address for queries */
+    uint16_t command_base_addr;        /* base address for commands */
+    uint16_t control_base_addr;        /* base address for controls */
+    uint16_t data_base_addr;        /* base address for datas */
+    unsigned int interrupt_base;    /* cross-function interrupt number
                                      * (uniq in the device)*/
-    unsigned int interrupt_count;	/* number of interrupts */
-    unsigned int report_size;	/* size of a report */
-    unsigned long irq_mask;		/* mask of the interrupts
-                                 * (to be applied against ATTN IRQ) */
+    unsigned int interrupt_count;    /* number of interrupts */
+    unsigned int report_size;    /* size of a report */
+    unsigned long irq_mask;        /* mask of the interrupts
+                                    * (to be applied against ATTN IRQ) */
 };
 
 
@@ -72,6 +72,8 @@ private:
     IOCommandGate* command_gate;
     UInt16 hid_descriptor_register;
     IOInterruptEventSource* interrupt_source;
+    
+    OSArray* transducers;
     
     uint16_t max_x;
     uint16_t max_y;
@@ -110,14 +112,14 @@ protected:
     const char* name;
     IOWorkLoop* work_loop;
     bool reading;
-
+    
 public:
     void stop(IOService* device) override;
     
     bool start(IOService* api);
     
     bool init(OSDictionary* properties);
-
+    
     VoodooI2CSynapticsDevice* probe(IOService* provider, SInt32* score);
     
     void interruptOccured(OSObject* owner, IOInterruptEventSource* src, int intCount);


### PR DESCRIPTION
I spent a few hours re-working the kext so it behaves well with my Razer Blade Stealth. Feel free to add/change the code. Here's what I did:

- Moved the transducer creation into the class (less overhead on reads since new objects aren't created, an added bonus is that we get state tracking thanks to the TimeTrackedValues)
- Removed reporting pressure values (causes inputs to be always considered as "presses or taps")
- Changed the IOKit personality so it properly loads (TODO: add name based filtering like ELAN kext)
- Changed physical button reads so it reflects the Linux Kernel (should properly work now)