### PR TITLE
Implement polling mode support in the Synaptics driver

### DIFF
--- a/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
+++ b/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
@@ -9,6 +9,7 @@
 
 #ifndef VoodooI2CSynapticsDevice_hpp
 #define VoodooI2CSynapticsDevice_hpp
+#define INTERRUPT_SIMULATOR_TIMEOUT 5
 
 #include <IOKit/IOLib.h>
 #include <IOKit/IOKitKeys.h>

--- a/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
+++ b/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.hpp
@@ -72,6 +72,7 @@ private:
     IOCommandGate* command_gate;
     UInt16 hid_descriptor_register;
     IOInterruptEventSource* interrupt_source;
+    IOTimerEventSource* interrupt_simulator; /* Sasha - Implement polling mode */
     
     OSArray* transducers;
     
@@ -155,6 +156,8 @@ public:
     void unpublish_multitouch_interface();
     
     void releaseResources();
+    
+    void simulateInterrupt(OSObject* owner, IOTimerEventSource* timer); /* Sasha - Implement polling mode */
 };
 
 


### PR DESCRIPTION
Some laptops have issues with GPIO pinning, such as high CPU usage, laggy cursor, or sometimes the trackpad will just stop working until sleep/wake. For some users the VoodooI2CHID kext doesn't have proper support for their trackpad, even though they can use polling mode. 

This PR fallback on polling if pin interrupts fails.